### PR TITLE
fixed remove comma in get_options function

### DIFF
--- a/bin/brew-file
+++ b/bin/brew-file
@@ -617,7 +617,7 @@ function get_options { # Get install options from brew info {{{
   elif [ "$v_inst" = "$v_head" ];then
     opt=" --HEAD"
   fi
-  opt=${opt}$(echo "$info"|grep "Built from source with"|cut -d: -f2)
+  opt=${opt}$(echo "$info"|grep "Built from source with"|cut -d: -f2|sed -e 's/, / /g')
   echo $opt
 } # }}}
 


### PR DESCRIPTION
Fixed problem.
Remove comma in install line options.

ex)
false:
install some-package --option-a, --option-b
true:
install some-package --option-a --option-b
