### PR TITLE
modify the default installation locations of Cask packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ in your setup file (e.g. .bashrc), like:
 
     export HOMEBREW_BREWFILE=~/.brewfile
 
+You can also modify the default installation locations of Cask packages.
+To make this settings, it is the same as issuing [How to Use Homebrew-cask#Options](https://github.com/caskroom/homebrew-cask/blob/master/USAGE.md#options).
+you might want to add the following line to your .bash_profile or .zshenv:
+
+    export HOMEBREW_CASK_OPTS="--caskroom=/etc/Caskroom"
+
 If there is no Brewfile, Brew-file ask you if you want to initialize Brewfile
 with installed packages.
 You can also make it with `-i` option.

--- a/bin/brew-file
+++ b/bin/brew-file
@@ -51,6 +51,12 @@ class BrewFile:
 
     def __init__(self):
         """initialization."""
+        import re
+        cask_opts = {"--caskroom" : ""}
+        env_cask_opts = os.environ.get("HOMEBREW_CASK_OPTS", "")
+        if env_cask_opts != "":
+            cask_opts = dict(map(lambda x: x.split("="),
+                                 re.split(r'(?<!\\)\s*', env_cask_opts)))
 
         self.opt = {}
 
@@ -66,7 +72,9 @@ class BrewFile:
         self.opt["initialized"] = False
         self.opt["tap_dir"]     = self.opt["brew_repo"] + "/Library/Taps"
         self.opt["cache_dir"]   = self.proc("brew --cache", False, False)[1][0]
-        self.opt["caskroom"]   = "/opt/homebrew-cask/Caskroom"
+        self.opt["caskroom"]    = cask_opts["--caskroom"] \
+                                  if cask_opts["--caskroom"] != "" \
+                                  else "/opt/homebrew-cask/Caskroom"
         self.opt["cask_pack"]   = "brew-cask"
         self.opt["cask_repo"]   = "caskroom/cask"
         self.opt["pip_pack"]    = "brew-pip"


### PR DESCRIPTION
homebrew-caskのインストール先を環境変数で指定できる機能を追加しました。

環境変数は公式と同様に `HOMEBREW_CASK_OPTS` の `--caskroom` を利用しています。
ref: https://github.com/caskroom/homebrew-cask/blob/master/USAGE.md#options

環境変数に記述があれば指定場所を参照します。
なければデフォルトの `/opt/homebrew-cask/Caskroom` を参照するようにしています。
