### PR TITLE
brew file edit throws error for certain $EDITOR variables

### DIFF
--- a/bin/brew-file
+++ b/bin/brew-file
@@ -1381,8 +1381,9 @@ class BrewFile:
 
     def edit_brewfile(self):
         """Edit brewfiles"""
-        import subprocess
-        subprocess.call([self.opt["my_editor"]] + self.get_files())
+        import shlex, subprocess
+        self.editor = shlex.split(self.opt["my_editor"])
+        subprocess.call(self.editor + self.get_files())
 
     def cat_brewfile(self):
         """Cat brewfiles"""


### PR DESCRIPTION
If the `$EDITOR` variable has whitespace in it (i.e. `export EDITOR="mate --wait"`), Python throws the following error when executing `brew file edit`:
```python
Traceback (most recent call last):
  File "/usr/local/bin/brew-file", line 2457, in <module>
    main()
  File "/usr/local/bin/brew-file", line 2454, in main
    b.execute()
  File "/usr/local/bin/brew-file", line 2146, in execute
    self.edit_brewfile()
  File "/usr/local/bin/brew-file", line 1385, in edit_brewfile
    subprocess.call([self.opt["my_editor"]] + self.get_files())
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

I did some digging and found that the issue stems from the `def edit_brewfile(self)` class. If there's a space in the `$EDITOR` variable called by `self.opt["my_editor"]` then the `subprocess.call` expects it to be an executable file path instead of a command with arguments, and throws up the aforementioned error. I tested the new code with a one-word `$EDITOR` variable and it worked fine, so this shouldn't cause any problems.