### PR TITLE
add environment support for using brew's ruby installation with brew-gem

### DIFF
--- a/bin/brew-file
+++ b/bin/brew-file
@@ -771,20 +771,10 @@ class BrewFile:
         self.opt["args"] = []
         self.opt["yn"] = False
         self.opt["brew_packages"] = ""
+        self.opt["homebrew_ruby"] = False
 
-        cask_opts = {"--caskroom": "", "--appdir": ""}
-        env_cask_opts = os.environ.get("HOMEBREW_CASK_OPTS", "")
-        try:
-            if env_cask_opts != "":
-                for o in env_cask_opts.split():
-                    oo = o.split("=")
-                    if len(oo) == 1:
-                        oo.append("")
-                    cask_opts.update({oo[0]: oo[1]})
-        except ValueError:
-            self.warning("HOMEBREW_CASK_OPTS: " + env_cask_opts +
-                         " is not a proper format.", 0)
-            self.warning("Ignore the value.\n", 0)
+        cask_opts = self.parse_env_opts("HOMEBREW_CASK_OPTS",
+            {"--caskroom": "", "--appdir": ""})
 
         if cask_opts["--caskroom"] != "":
             self.opt["caskroom"] = cask_opts["--caskroom"]
@@ -809,6 +799,10 @@ class BrewFile:
         self.opt["appstore"] = to_bool(
             os.environ.get("HOMEBREW_BREWFILE_APPSTORE", True))
 
+        gem_opts = self.parse_env_opts("HOMEBREW_GEM_OPTS")
+        if "--homebrew-ruby" in gem_opts:
+            self.opt["homebrew_ruby"] = True
+
         self.int_opts = ["verbose"]
         self.float_opts = []
 
@@ -817,6 +811,33 @@ class BrewFile:
 
         self.pack_deps = {}
         self.top_packs = []
+
+    def parse_env_opts(self, env_var, base_opts=None):
+        """Returns a dictionary parsed from an environment variable"""
+
+        if base_opts is not None:
+            opts = base_opts.copy()
+        else:
+            opts = {}
+
+        env_var = env_var.upper()
+        env_opts = os.environ.get(env_var, None)
+        if env_opts:
+
+            # these can be flags ("--flag") or values ("--key=value")
+            # but not weirdness ("--foo=bar=baz")
+            user_opts = {key.lower(): value for (key, value) in
+                [pair.partition("=")[::2] for pair in env_opts.split() if
+                    pair.count("=") < 2]}
+
+            if user_opts:
+                opts.update(user_opts)
+            else:
+                self.warning("%s: \"%s\" is not a proper format." % (env_var,
+                    env_opts), 0)
+                self.warning("Ignoring the value.\n", 0)
+
+        return opts
 
     def set_args(self, **kw):
         """Set arguments."""
@@ -1174,6 +1195,8 @@ class BrewFile:
             self.check_pip_cmd(True)
         elif self.opt["args"][0] == "gem":
             self.check_gem_cmd(True)
+            if self.opt["homebrew_ruby"] and not "--homebrew-ruby" in self.opt["args"]:
+                self.opt["args"].append("--homebrew-ruby")
 
         (ret, lines) = self.proc(["brew"] + self.opt["args"],
                                  True, True, False)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -14,3 +14,4 @@ Following environmental variables can be used.
    HOMEBREW_BREWFILE_VERBOSE      | Set verbose level. | 1
    HOMEBREW_BREWFILE_APPSTORE     | Set 0 you don't want to list up AppStore applications Brewfile. | 1
    HOMEBREW_CASK_OPTS             | This is `Cask's option <https://github.com/caskroom/homebrew-cask/blob/master/USAGE.md>`_ to set cask environment. If caskroom or appdir is set with these options, Brew-file uses these values in it. | \"\"
+   HOMEBREW_GEM_OPTS              | This is `brew-gem's option <https://github.com/sportngin/brew-gem/blob/master/README.md>`_ to set Ruby environment. | \"\"

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -25,6 +25,12 @@ You might want to add the following line to your **.bashrc** or **.zshenv**:
 
     export HOMEBREW_CASK_OPTS="--caskroom=/etc/Caskroom --appdir=$HOME/MyApplications"
 
+Similarly, you can specify the environment for brew-gem.  The following will tell brew-gem to use the Ruby installed by Homebrew itself:
+
+.. code-block:: sh
+
+    export HOMEBREW_GEM_OPTS="--homebrew-ruby"
+
 If there is no ``Brewfile``, Brew-file will ask you if you want to initialize ``Brewfile``
 with installed packages or not.
 You can also make it with ``install`` (``-i``) subcommand.


### PR DESCRIPTION
- the `--homebrew-ruby` flag to `brew-gem` will tell it to use the Ruby as installed by Homebrew (see sportngin/brew-gem#29)
- allow `HOMEBREW_GEM_OPTS` environment variable so users don't need to type `--homebrew-ruby` every time
- updated docs

 * * *

I had some questions here:

- Not entirely sure about the formatting used in `brew-file`, but I did my best.
- Only `--homebrew-ruby` is supported by `HOMEBREW_GEM_OPTS`, but I could change this to allow anything.  As-is, it's pretty defensive to have it be explicit, and adds edge-case conditionals around the code.
- A better solution may be generic option support via an env var for both this and `brew-pip`...