### PR TITLE
Use diff directly, no aliases or functions

### DIFF
--- a/etc/brew-wrap
+++ b/etc/brew-wrap
@@ -65,7 +65,7 @@ brew () {
   ret=$?
 
   # Commands after brew command
-  if ! diff <(echo "$brewfile") <(brew-file cat) >/dev/null;then
+  if ! command diff <(echo "$brewfile") <(brew-file cat) >/dev/null;then
     _post_brewfile_update
   fi
 


### PR DESCRIPTION
File descriptors errors may be encountered without explicitly ignoring
diff functions.