### PR TITLE
fix case syntax for fish

### DIFF
--- a/etc/brew-wrap.fish
+++ b/etc/brew-wrap.fish
@@ -37,7 +37,7 @@ function brew
           set exe "brew-file brew"
         end
       end
-    case *
+    case '*'
       if echo " brew init dump set_repo set_local pull push clean clean_non_request casklist get_files version "|grep -q -- " $argv[1] "
         set exe "brew-file"
       end


### PR DESCRIPTION
currently the wrap not working for the syntax is not correct according to the fish [doc](https://fishshell.com/docs/current/cmds/case.html):

>   # Note that the next case has a wildcard which is quoted
>    case '*'
>        echo I have no idea what a $animal is