### PR TITLE
Update brew info related functions (for brew file init, ect...)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,8 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
         with:
           test-bot: false
+      - name: Install wget
+        run: brew install wget
       - uses: rcmdnk/python-action@v2
         with:
           checkout: 1

--- a/bin/brew-file
+++ b/bin/brew-file
@@ -2887,24 +2887,21 @@ class BrewFile:
         casks: dict[str, dict[str, str | bool]] = {}
         apps: dict[str, str] = {}
         installed_casks: dict[str, list[str]] = {self.opt["cask_repo"]: []}
-        for cask_info in info:
+        for cask in info:
             apps_in_cask = []
-            # installed = True if cask_info["installed"] is not None else False
-            installed = cask_info["token"] in cask_list
+            installed = cask in cask_list
             latest = False
             if installed:
-                if cask_info["installed"] is None:
-                    # No AMI info by --eval-all, using json, which does not have installed information
-                    # In addition, some AMI casks (e.g. firefox, zoom) can not work with brew info.
+                if info[cask]["installed"] is None:
                     latest = True
                 else:
-                    latest = cask_info["installed"] == cask_info["version"]
-                installed_casks[cask_info["tap"]] = installed_casks.get(
-                    cask_info["tap"], []
-                ) + [cask_info["token"]]
+                    latest = info[cask]["installed"] == info[cask]["version"]
+                installed_casks[info[cask]["tap"]] = installed_casks.get(
+                    info[cask]["tap"], []
+                ) + [cask]
 
-            if "artifacts" in cask_info:
-                for artifact in cask_info["artifacts"]:
+            if "artifacts" in info[cask]:
+                for artifact in info[cask]["artifacts"]:
                     if "app" in artifact:
                         for a in artifact["app"]:
                             if isinstance(a, str):
@@ -2917,15 +2914,15 @@ class BrewFile:
                                         ".app"
                                     ):
                                         apps_in_cask.append(a)
-            casks[cask_info["token"]] = {
-                "tap": cask_info["tap"],
+            casks[cask] = {
+                "tap": info[cask]["tap"],
                 "installed": installed,
                 "latest": latest,
             }
             apps_in_cask = list(set(apps_in_cask))
             for a in apps_in_cask:
                 if a not in apps or installed:
-                    apps[a] = cask_info["token"]
+                    apps[a] = cask
         # brew
         formulae = self.helper.get_formula_list()
         formulae_all = self.helper.get_all_formulae()

--- a/bin/brew-file
+++ b/bin/brew-file
@@ -412,8 +412,10 @@ class BrewHelper:
             "casks": [x.split("/")[-1] for x in self.taps[tap]["cask_tokens"]],
         }
         if alias:
-            packs["formulae"] += self.get_formula_aliases().get(tap, {}).keys()
-            packs["casks"] += self.get_cask_aliases().get(tap, {}).keys()
+            packs["formulae"] += list(
+                self.get_formula_aliases().get(tap, {}).keys()
+            )
+            packs["casks"] += list(self.get_cask_aliases().get(tap, {}).keys())
         return packs
 
     def get_leaves(self, on_request: bool = False) -> list[str]:
@@ -911,12 +913,15 @@ fi
             for t in self.tap_list:
                 isfirst_pack = True
                 direct_first = False
-                tap_packs = self.helper.get_tap_packs(t)
 
                 if t == "direct":
-                    if not tap_packs["formulae"] and not tap_packs["casks"]:
-                        continue
                     direct_first = True
+                    tap_packs: dict[str, list[str]] = {
+                        "formulae": [],
+                        "casks": [],
+                    }
+                else:
+                    tap_packs = self.helper.get_tap_packs(t)
 
                 if not self.helper.opt["caskonly"]:
                     output += first_tap_pack_write(
@@ -2595,7 +2600,7 @@ class BrewFile:
         if self.get_list("tap_list"):
             self.banner("# Clean up tap packages")
             for p in self.get_list("tap_list"):
-                if p in self.get_list("tap_input"):
+                if p in self.get_list("tap_input") or p == "direct":
                     continue
                 packs = self.helper.get_tap_packs(p)
                 untapflag = True

--- a/bin/brew-file
+++ b/bin/brew-file
@@ -649,7 +649,6 @@ class BrewInfo:
         with open(self.file, "r") as f:
             lines = f.readlines()
             is_ignore = False
-            self.tap_input.append("direct")
             for line in lines:
                 if re.match("# *BREWFILE_ENDIGNORE", line):
                     is_ignore = False
@@ -898,7 +897,6 @@ fi
 
             def first_tap_pack_write(
                 isfirst: bool,
-                direct_first: bool,
                 isfirst_pack: bool,
                 tap: str,
                 cmd_tap: str,
@@ -906,26 +904,18 @@ fi
                 output = ""
                 if isfirst:
                     output += "\n# tap repositories and their packages\n"
-                if not direct_first and isfirst_pack:
+                if isfirst_pack:
                     output += "\n" + cmd_tap + self.packout(tap) + "\n"
                 return output
 
             for t in self.tap_list:
                 isfirst_pack = True
-                direct_first = False
 
-                if t == "direct":
-                    direct_first = True
-                    tap_packs: dict[str, list[str]] = {
-                        "formulae": [],
-                        "casks": [],
-                    }
-                else:
-                    tap_packs = self.helper.get_tap_packs(t)
+                tap_packs = self.helper.get_tap_packs(t)
 
                 if not self.helper.opt["caskonly"]:
                     output += first_tap_pack_write(
-                        isfirst, direct_first, isfirst_pack, t, cmd_tap
+                        isfirst, isfirst_pack, t, cmd_tap
                     )
                     isfirst = isfirst_pack = False
 
@@ -934,9 +924,6 @@ fi
                             p.split("/")[-1].replace(".rb", "")
                             in tap_packs["formulae"]
                         ):
-                            if direct_first:
-                                direct_first = False
-                                output += "\n## " + "Direct install\n"
                             pack = self.packout(p) + self.convert_option(
                                 self.brew_list_opt[p]
                             )
@@ -949,7 +936,7 @@ fi
                 for p in self.cask_list[:]:
                     if p in tap_casks:
                         output += first_tap_pack_write(
-                            isfirst, False, isfirst_pack, t, cmd_tap
+                            isfirst, isfirst_pack, t, cmd_tap
                         )
                         isfirst = isfirst_pack = False
                         output += cmd_cask + self.packout(p) + "\n"
@@ -2121,7 +2108,6 @@ class BrewFile:
             and self.opt["cask_repo"] not in self.brewinfo.get_list("tap_list")
         ):
             self.brewinfo.add_to_list("tap_list", [self.opt["cask_repo"]])
-        self.brewinfo.add_to_list("tap_list", ["direct"])
 
         # Casks
         if is_mac():
@@ -2600,7 +2586,7 @@ class BrewFile:
         if self.get_list("tap_list"):
             self.banner("# Clean up tap packages")
             for p in self.get_list("tap_list"):
-                if p in self.get_list("tap_input") or p == "direct":
+                if p in self.get_list("tap_input"):
                     continue
                 packs = self.helper.get_tap_packs(p)
                 untapflag = True
@@ -2655,7 +2641,7 @@ class BrewFile:
 
         # Tap
         for p in self.get_list("tap_input"):
-            if p in self.get_list("tap_list") or p == "direct":
+            if p in self.get_list("tap_list"):
                 continue
             _ = self.helper.proc("brew tap " + p, dryrun=self.opt["dryrun"])
 

--- a/bin/brew-file
+++ b/bin/brew-file
@@ -166,7 +166,7 @@ class StrRe(str):
 
 
 if TYPE_CHECKING:
-    from typing_extensions import NotRequired, Unpack
+    from typing_extensions import NotRequired
 
     class ProcParams(TypedDict):
         """Parameters for BrewHelper.proc()."""
@@ -195,9 +195,17 @@ class BrewHelper:
     """Helper functions for BrewFile."""
 
     opt: dict[str, Any] = field(default_factory=dict)
-    log: logging.Logger = field(
-        default_factory=lambda: logging.getLogger(__name__)
-    )
+
+    def __post_init__(self) -> None:
+        self.log = logging.getLogger(__name__)
+
+        self.info: dict[str, dict[str, Any]] | None = None
+        self.all_formulae: dict[str, Any] | None = None
+        self.formula_aliases: dict[str, dict[str, str]] | None = None
+        self.cask_aliases: dict[str, dict[str, str]] | None = None
+        self.taps: dict[str, Any] | None = None
+        self.leaves_list: list[str] | None = None
+        self.leaves_list_on_request: list[str] | None = None
 
     def readstdout(
         self, proc: subprocess.Popen[str]
@@ -281,92 +289,80 @@ class BrewHelper:
             self.opt[name] = lines[0]
         return self.opt[name]
 
+    def get_info(self) -> dict[str, Any]:
+        """Get info of installed brew package."""
+        if self.info is None:
+            _, lines = self.proc(
+                cmd="brew info --json=v2 --installed",
+                print_cmd=False,
+                print_out=False,
+                exit_on_err=True,
+                separate_err=True,
+            )
+            lines = lines[lines.index("{") :]
+            data = json.loads("".join(lines))
+            self.info = {
+                "formulae": {x["name"]: x for x in data["formulae"]},
+                "casks": {x["token"]: x for x in data["casks"]},
+            }
+        return self.info
+
+    def get_all_formulae(self) -> dict[str, Any]:
+        """Get info of all formulae."""
+        if self.all_formulae is None:
+            _, lines = self.proc(
+                cmd="brew info --json=v1 --eval-all",
+                print_cmd=False,
+                print_out=False,
+                exit_on_err=True,
+                separate_err=True,
+            )
+            lines = lines[lines.index("[") :]
+            data = json.loads("".join(lines))
+            self.all_formulae = {x["name"]: x for x in data}
+        return self.all_formulae
+
     def get_formula_list(self) -> list[str]:
-        _, lines = self.proc(
-            "brew list --formula",
-            print_cmd=False,
-            print_out=False,
-            separate_err=True,
-            print_err=False,
-        )
-        packages = []
-        for line in lines:
-            if (
-                "Warning: nothing to list" in line
-                or "=>" in line
-                or "->" in line
-            ):
-                continue
-            packages.append(line)
-        return packages
+        info = self.get_info()
+        return list(info["formulae"].keys())
 
     def get_cask_list(self) -> list[str]:
-        _, lines = self.proc(
-            "brew list --cask",
-            print_cmd=False,
-            print_out=False,
-            separate_err=True,
-            print_err=False,
-        )
-        packages = []
-        for line in lines:
-            if (
-                "Warning: nothing to list" in line
-                or "=>" in line
-                or "->" in line
-            ):
-                continue
-            packages.append(line)
-        return packages
+        info = self.get_info()
+        return list(info["casks"].keys())
 
-    def brew_info_v1(
-        self,
-        info_opt: str,
-        **kw: Unpack[ProcParams],
-    ) -> list[dict[str, Any]]:
-        params: ProcParams = {
-            "cmd": "brew info --json=v1 " + info_opt,
-        }
-        params.update(kw)
-        _, lines = self.proc(**params)
-        info = lines[lines.index("[") :]
-        return json.loads("".join(info))
+    def get_formula_aliases(self) -> dict[str, dict[str, str]]:
+        if self.formula_aliases is None:
+            self.formula_aliases = {}
+            info = self.get_info()
+            for formula in info["formulae"].values():
+                tap = formula["tap"]
+                for o in formula.get("oldnames", []):
+                    self.formula_aliases[tap] = self.formula_aliases.get(
+                        tap, {}
+                    )
+                    self.formula_aliases[tap][o] = formula["name"]
+                for a in formula.get("aliases", []):
+                    self.formula_aliases[tap] = self.formula_aliases.get(
+                        tap, {}
+                    )
+                    self.formula_aliases[tap][a] = formula["name"]
+        return self.formula_aliases
 
-    def brew_info_v2(
-        self,
-        info_opt: str,
-        **kw: Unpack[ProcParams],
-    ) -> dict[str, Any]:
-        params: ProcParams = {
-            "cmd": "brew info --json=v2 " + info_opt,
-        }
-        params.update(kw)
-        _, lines = self.proc(**params)
-        info = lines[lines.index("{") :]
-        return json.loads("".join(info))
+    def get_cask_aliases(self) -> dict[str, dict[str, str]]:
+        if self.cask_aliases is None:
+            self.cask_aliases = {}
+            info = self.get_info()
+            for cask in info["casks"].values():
+                tap = cask["tap"]
+                for o in cask.get("old_tokens", []):
+                    self.cask_aliases[tap] = self.cask_aliases.get(tap, {})
+                    self.cask_aliases[tap][o] = cask["name"]
+        return self.cask_aliases
 
-    def get_info(self, package: str = "") -> dict[str, Any]:
-        if package == "":
-            package = "--installed"
-        infotmp = self.brew_info_v1(
-            info_opt=package,
-            print_cmd=False,
-            print_out=False,
-            exit_on_err=True,
-            separate_err=True,
-        )
-        info: dict[str, Any] = {}
-        for i in infotmp:
-            info[i["name"]] = i
-        return info
-
-    def get_installed(
-        self, package: str, package_info: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
+    def get_installed(self, package: str) -> dict[str, Any]:
         """Get installed version of brew package."""
         installed = {}
-        if package_info is None:
-            package_info = self.get_info(package)[package]
+        package_info = self.get_info()["formulae"][package]
 
         if (version := package_info["linked_keg"]) is None:
             version = package_info["installed"][-1]["version"]
@@ -378,105 +374,72 @@ class BrewHelper:
                     break
         return installed
 
-    def get_option(
-        self, package: str, package_info: dict[str, Any] | None = None
-    ) -> str:
+    def get_option(self, package: str) -> str:
         """Get install options from brew info."""
-        # Get options for build
-        if package_info is None:
-            package_info = self.get_info(package)[package]
-
         opt = ""
-        installed = self.get_installed(package, package_info)
-        if used_options := installed.get("used_options", []):
+        if used_options := self.get_installed(package).get("used_options", []):
             opt = " " + " ".join(used_options)
-        for k, v in package_info.get("versions", {}).items():
-            if installed.get("version", None) == v and k != "stable":
-                if k == "head":
-                    opt += " --HEAD"
-                else:
-                    opt += " --" + k
+        if version := self.get_installed(package).get("version", None):
+            info = self.get_info()["formulae"][package]
+
+            for k, v in info.get("versions", {}).items():
+                if version == v and k != "stable":
+                    if k == "head":
+                        opt += " --HEAD"
+                    else:
+                        opt += " --" + k
         return opt
 
-    def get_formula_info(self) -> list[dict[str, Any]]:
-        if "formula_info" in self.opt:
-            return self.opt["formula_info"]
+    def get_tap_packs(
+        self, tap: str, alias: bool = False
+    ) -> dict[str, list[str]]:
+        if self.taps is None:
+            _, lines = self.proc(
+                cmd="brew tap-info --json --installed",
+                print_cmd=False,
+                print_out=False,
+                exit_on_err=True,
+                separate_err=True,
+            )
+            lines = lines[lines.index("[") :]
+            data = json.loads("".join(lines))
+            self.taps = {x["name"]: x for x in data}
 
-        info = self.brew_info_v1(
-            info_opt="--eval-all", print_cmd=False, print_out=False
-        )
-        if (
-            not [x for x in info if x["tap"] == self.opt["core_repo"]]
-            and self.opt["api"]
-        ):
-            formula_json = Path(self.opt["cache"]) / "api" / "formula.jws.json"
-            if not formula_json.exists():
-                _ = self.proc("brew update")
-            with open(formula_json, "r") as f:
-                info_api = json.loads(json.load(f)["payload"])
-            info = info_api + info
-        self.opt["formula_info"] = info
-        return info
-
-    def get_formula_aliases(self) -> dict[str, str]:
-        if "formula_aliases" in self.opt:
-            return self.opt["formula_aliases"]
-        info = self.get_formula_info()
-        self.opt["formula_aliases"] = {}
-        for i in info:
-            if "aliases" in i:
-                for a in i["aliases"]:
-                    self.opt["formula_aliases"][a] = i["name"]
-        return self.opt["formula_aliases"]
-
-    def get_tap_packs(self, tap: str) -> list[str]:
-        packs = [x["name"] for x in self.get_formula_info() if x["tap"] == tap]
-        packs_aliases = [
-            k for k, v in self.get_formula_aliases().items() if v in packs
-        ]
-        return packs + packs_aliases
-
-    def get_cask_info(self) -> Any:
-        if "cask_info" in self.opt:
-            return self.opt["cask_info"]
-
-        info = self.brew_info_v2(
-            info_opt="--eval-all", print_cmd=False, print_out=False
-        )["casks"]
-        if (
-            not [x for x in info if x["tap"] == self.opt["cask_repo"]]
-            and self.opt["api"]
-        ):
-            cask_json = Path(self.opt["cache"]) / "api" / "cask.jws.json"
-            if not cask_json.exists():
-                _ = self.proc("brew update")
-            with open(cask_json, "r") as f:
-                info_api = json.loads(json.load(f)["payload"])
-            info = info_api + info
-        self.opt["cask_info"] = info
-        return info
-
-    def get_tap_casks(self, tap: str) -> list[str]:
-        return sorted(
-            [x["token"] for x in self.get_cask_info() if x["tap"] == tap]
-        )
+        packs = {
+            "formulae": [
+                x.split("/")[-1] for x in self.taps[tap]["formula_names"]
+            ],
+            "casks": [x.split("/")[-1] for x in self.taps[tap]["cask_tokens"]],
+        }
+        if alias:
+            packs["formulae"] += self.get_formula_aliases().get(tap, {}).keys()
+            packs["casks"] += self.get_cask_aliases().get(tap, {}).keys()
+        return packs
 
     def get_leaves(self, on_request: bool = False) -> list[str]:
-        var_name = f"leaves_list_{on_request}"
-        if var_name in self.opt:
-            return self.opt[var_name]
+        if on_request:
+            leaves_list = self.leaves_list_on_request
+        else:
+            leaves_list = self.leaves_list
+
+        if leaves_list is not None:
+            return leaves_list
+
         cmd = "brew leaves"
         if on_request:
             cmd += " --installed-on-request"
-        _, leaves_list = self.proc(
+        _, lines = self.proc(
             cmd,
             print_cmd=False,
             print_out=False,
             separate_err=True,
             print_err=False,
         )
-        leaves_list = [x.split("/")[-1] for x in leaves_list]
-        self.opt[var_name] = leaves_list
+        leaves_list = [x.split("/")[-1] for x in lines]
+        if on_request:
+            self.leaves_list_on_request = leaves_list
+        else:
+            self.leaves_list = leaves_list
         return leaves_list
 
 
@@ -486,11 +449,9 @@ class BrewInfo:
 
     helper: BrewHelper
     file: Path = field(default_factory=lambda: Path())
-    log: logging.Logger = field(
-        default_factory=lambda: logging.getLogger(__name__)
-    )
 
     def __post_init__(self) -> None:
+        self.log = logging.getLogger(__name__)
         self.brew_input_opt: dict[str, str] = {}
 
         self.brew_input: list[str] = []
@@ -753,11 +714,12 @@ class BrewInfo:
                 elif cmd == "tapall":
                     _ = self.helper.proc(f"brew tap {p}")
                     self.tap_input.append(p)
-                    for tp in self.helper.get_tap_packs(p):
+                    tap_packs = self.helper.get_tap_packs(p)
+                    for tp in tap_packs["formulae"]:
                         self.brew_input.append(tp)
                         self.brew_input_opt[tp] = ""
                     if is_mac():
-                        for tp in self.helper.get_tap_casks(p):
+                        for tp in tap_packs["casks"]:
                             self.cask_input.append(tp)
                 elif cmd == "cask":
                     self.cask_input.append(p)
@@ -952,7 +914,7 @@ fi
                 tap_packs = self.helper.get_tap_packs(t)
 
                 if t == "direct":
-                    if not tap_packs:
+                    if not tap_packs["formulae"] and not tap_packs["casks"]:
                         continue
                     direct_first = True
 
@@ -963,7 +925,10 @@ fi
                     isfirst = isfirst_pack = False
 
                     for p in self.brew_list[:]:
-                        if p.split("/")[-1].replace(".rb", "") in tap_packs:
+                        if (
+                            p.split("/")[-1].replace(".rb", "")
+                            in tap_packs["formulae"]
+                        ):
                             if direct_first:
                                 direct_first = False
                                 output += "\n## " + "Direct install\n"
@@ -975,7 +940,7 @@ fi
                             del self.brew_list_opt[p]
                 if not is_mac():
                     continue
-                tap_casks = self.helper.get_tap_casks(t)
+                tap_casks = tap_packs["casks"]
                 for p in self.cask_list[:]:
                     if p in tap_casks:
                         output += first_tap_pack_write(
@@ -2104,7 +2069,6 @@ class BrewFile:
 
         # Brew packages
         if not self.opt["caskonly"]:
-            info = self.helper.get_info()
             full_list = self.helper.get_formula_list()
             self.brewinfo.brew_full_list.extend(full_list)
             if self.opt["leaves"]:
@@ -2113,8 +2077,8 @@ class BrewFile:
                 )
             elif self.opt["on_request"]:
                 packages = []
-                for p in info:
-                    installed = self.helper.get_installed(p, info[p])
+                for p in full_list:
+                    installed = self.helper.get_installed(p)
                     if installed.get("installed_on_request", True) in [
                         True,
                         None,
@@ -2132,9 +2096,7 @@ class BrewFile:
 
             for p in packages:
                 self.brewinfo.brew_list.append(p)
-                self.brewinfo.brew_list_opt[p] = self.helper.get_option(
-                    p, info[p]
-                )
+                self.brewinfo.brew_list_opt[p] = self.helper.get_option(p)
 
         # Taps
         _, lines = self.helper.proc(
@@ -2197,24 +2159,54 @@ class BrewFile:
     def clean_list(self) -> None:
         """Remove duplications between brewinfo.list to extra files' input."""
         # Cleanup extra files
-        aliases = self.helper.get_formula_aliases()
+        formula_aliases = {}
+        for aliases in self.helper.get_formula_aliases().values():
+            formula_aliases.update(aliases)
+        cask_aliases = {}
+        for aliases in self.helper.get_cask_aliases().values():
+            cask_aliases.update(aliases)
+
         for b in self.brewinfo_ext + [self.brewinfo_main]:
             for line in ["brew", "tap", "cask", "appstore"]:
                 for p in b.get_list(line + "_input"):
                     # Keep aliases
-                    if line == "brew" and p in aliases:
-                        if aliases[p] in self.brewinfo.get_list("brew_list"):
+                    if line == "brew" and p in formula_aliases:
+                        if formula_aliases[p] in self.brewinfo.get_list(
+                            "brew_list"
+                        ):
                             self.brewinfo.add_to_list("brew_list", [p])
                             self.brewinfo.add_to_dict(
                                 "brew_list_opt",
                                 {
                                     p: self.brewinfo.get_dict("brew_list_opt")[
-                                        aliases[p]
+                                        formula_aliases[p]
                                     ]
                                 },
                             )
-                            self.brewinfo.remove("brew_list", aliases[p])
-                            self.brewinfo.remove("brew_list_opt", aliases[p])
+                            self.brewinfo.remove(
+                                "brew_list", formula_aliases[p]
+                            )
+                            self.brewinfo.remove(
+                                "brew_list_opt", formula_aliases[p]
+                            )
+                    if line == "cask" and p in cask_aliases:
+                        if cask_aliases[p] in self.brewinfo.get_list(
+                            "cask_list"
+                        ):
+                            self.brewinfo.add_to_list("cask_list", [p])
+                            self.brewinfo.add_to_dict(
+                                "cask_list_args_input",
+                                {
+                                    p: self.brewinfo.get_dict(
+                                        "cask_list_args_input"
+                                    )[cask_aliases[p]]
+                                },
+                            )
+                            self.brewinfo.remove("cask_list", cask_aliases[p])
+                            self.brewinfo.remove(
+                                "cask_list_args_input", cask_aliases[p]
+                            )
+
                     if p not in self.brewinfo.get_list(line + "_list"):
                         b.remove(line + "_input", p)
 
@@ -2410,12 +2402,12 @@ class BrewFile:
 
     def clean_non_request(self) -> None:
         """Clean up non requested packages."""
-        info = self.helper.get_info()
+        formulae = self.helper.get_formula_list()
         leaves = self.helper.get_leaves()
-        for p in info:
+        for p in formulae:
             if p not in leaves:
                 continue
-            installed = self.helper.get_installed(p, info[p])
+            installed = self.helper.get_installed(p)
             if installed.get("installed_on_request", False) is False:
                 cmd = "brew uninstall " + p
                 _ = self.helper.proc(
@@ -2432,7 +2424,7 @@ class BrewFile:
 
         # Check up packages in the input file
         self.read_all()
-        info = self.helper.get_info()
+        info = self.helper.get_info()["formulae"]
 
         def add_dependncies(package: str) -> None:
             for pac in info[package]["dependencies"]:
@@ -2605,8 +2597,9 @@ class BrewFile:
             for p in self.get_list("tap_list"):
                 if p in self.get_list("tap_input"):
                     continue
+                packs = self.helper.get_tap_packs(p)
                 untapflag = True
-                for tp in self.helper.get_tap_packs(p):
+                for tp in packs["formulae"]:
                     if tp in self.get_list("brew_input"):
                         # Keep the Tap as related package is remained
                         untapflag = False
@@ -2614,7 +2607,7 @@ class BrewFile:
                 if not untapflag:
                     continue
                 if is_mac():
-                    for tc in self.helper.get_tap_casks(p):
+                    for tc in packs["casks"]:
                         if tc in self.get_list("cask_input"):
                             # Keep the Tap as related cask is remained
                             untapflag = False
@@ -2684,10 +2677,12 @@ class BrewFile:
         # brew
         if not self.opt["caskonly"]:
             # Brew
-            aliases = self.helper.get_formula_aliases()
+            formula_aliases = {}
+            for aliases in self.helper.get_formula_aliases().values():
+                formula_aliases.update(aliases)
             for p in self.get_list("brew_input"):
                 cmd = "install"
-                pack = aliases[p] if p in aliases else p
+                pack = formula_aliases[p] if p in formula_aliases else p
                 if pack in self.get_list("brew_full_list"):
                     if p not in self.get_dict("brew_list_opt") or sorted(
                         self.get_dict("brew_input_opt")[p].split()
@@ -2888,7 +2883,7 @@ class BrewFile:
         cask_list = self.helper.get_cask_list()
 
         # Get cask information
-        info = self.helper.get_cask_info()
+        info = self.helper.get_info()["casks"]
         casks: dict[str, dict[str, str | bool]] = {}
         apps: dict[str, str] = {}
         installed_casks: dict[str, list[str]] = {self.opt["cask_repo"]: []}
@@ -2933,10 +2928,7 @@ class BrewFile:
                     apps[a] = cask_info["token"]
         # brew
         formulae = self.helper.get_formula_list()
-        brews = {
-            x["name"]: {"tap": x["tap"], "installed": x["name"] in formulae}
-            for x in self.helper.get_formula_info()
-        }
+        formulae_all = self.helper.get_all_formulae()
 
         # Set applications directories
         app_dirs = self.opt["appdirlist"]
@@ -3016,9 +3008,9 @@ class BrewFile:
                             has_cask_apps[cask_tap] = has_cask_apps.get(
                                 cask_tap, []
                             ) + [(app_path, token)]
-                    elif token in brews:
-                        brew_tap = cast(str, brews[token]["tap"])
-                        if brews[token]["installed"]:
+                    elif token in formulae_all:
+                        brew_tap = cast(str, formulae_all[token]["tap"])
+                        if token in formulae:
                             check = "brew"
                             brew_apps[brew_tap] = brew_apps.get(
                                 brew_tap, []

--- a/src/brew_file/brew_file.py
+++ b/src/brew_file/brew_file.py
@@ -1572,7 +1572,7 @@ class BrewFile:
         if self.get_list("tap_list"):
             self.banner("# Clean up tap packages")
             for p in self.get_list("tap_list"):
-                if p in self.get_list("tap_input"):
+                if p in self.get_list("tap_input") or p == "direct":
                     continue
                 packs = self.helper.get_tap_packs(p)
                 untapflag = True

--- a/src/brew_file/brew_file.py
+++ b/src/brew_file/brew_file.py
@@ -1864,24 +1864,21 @@ class BrewFile:
         casks: dict[str, dict[str, str | bool]] = {}
         apps: dict[str, str] = {}
         installed_casks: dict[str, list[str]] = {self.opt["cask_repo"]: []}
-        for cask_info in info:
+        for cask in info:
             apps_in_cask = []
-            # installed = True if cask_info["installed"] is not None else False
-            installed = cask_info["token"] in cask_list
+            installed = cask in cask_list
             latest = False
             if installed:
-                if cask_info["installed"] is None:
-                    # No AMI info by --eval-all, using json, which does not have installed information
-                    # In addition, some AMI casks (e.g. firefox, zoom) can not work with brew info.
+                if info[cask]["installed"] is None:
                     latest = True
                 else:
-                    latest = cask_info["installed"] == cask_info["version"]
-                installed_casks[cask_info["tap"]] = installed_casks.get(
-                    cask_info["tap"], []
-                ) + [cask_info["token"]]
+                    latest = info[cask]["installed"] == info[cask]["version"]
+                installed_casks[info[cask]["tap"]] = installed_casks.get(
+                    info[cask]["tap"], []
+                ) + [cask]
 
-            if "artifacts" in cask_info:
-                for artifact in cask_info["artifacts"]:
+            if "artifacts" in info[cask]:
+                for artifact in info[cask]["artifacts"]:
                     if "app" in artifact:
                         for a in artifact["app"]:
                             if isinstance(a, str):
@@ -1894,15 +1891,15 @@ class BrewFile:
                                         ".app"
                                     ):
                                         apps_in_cask.append(a)
-            casks[cask_info["token"]] = {
-                "tap": cask_info["tap"],
+            casks[cask] = {
+                "tap": info[cask]["tap"],
                 "installed": installed,
                 "latest": latest,
             }
             apps_in_cask = list(set(apps_in_cask))
             for a in apps_in_cask:
                 if a not in apps or installed:
-                    apps[a] = cask_info["token"]
+                    apps[a] = cask
         # brew
         formulae = self.helper.get_formula_list()
         formulae_all = self.helper.get_all_formulae()

--- a/src/brew_file/brew_file.py
+++ b/src/brew_file/brew_file.py
@@ -1093,7 +1093,6 @@ class BrewFile:
             and self.opt["cask_repo"] not in self.brewinfo.get_list("tap_list")
         ):
             self.brewinfo.add_to_list("tap_list", [self.opt["cask_repo"]])
-        self.brewinfo.add_to_list("tap_list", ["direct"])
 
         # Casks
         if is_mac():
@@ -1572,7 +1571,7 @@ class BrewFile:
         if self.get_list("tap_list"):
             self.banner("# Clean up tap packages")
             for p in self.get_list("tap_list"):
-                if p in self.get_list("tap_input") or p == "direct":
+                if p in self.get_list("tap_input"):
                     continue
                 packs = self.helper.get_tap_packs(p)
                 untapflag = True
@@ -1627,7 +1626,7 @@ class BrewFile:
 
         # Tap
         for p in self.get_list("tap_input"):
-            if p in self.get_list("tap_list") or p == "direct":
+            if p in self.get_list("tap_list"):
                 continue
             _ = self.helper.proc("brew tap " + p, dryrun=self.opt["dryrun"])
 

--- a/src/brew_file/brew_helper.py
+++ b/src/brew_file/brew_helper.py
@@ -256,8 +256,10 @@ class BrewHelper:
             "casks": [x.split("/")[-1] for x in self.taps[tap]["cask_tokens"]],
         }
         if alias:
-            packs["formulae"] += self.get_formula_aliases().get(tap, {}).keys()
-            packs["casks"] += self.get_cask_aliases().get(tap, {}).keys()
+            packs["formulae"] += list(
+                self.get_formula_aliases().get(tap, {}).keys()
+            )
+            packs["casks"] += list(self.get_cask_aliases().get(tap, {}).keys())
         return packs
 
     def get_leaves(self, on_request: bool = False) -> list[str]:

--- a/src/brew_file/brew_info.py
+++ b/src/brew_file/brew_info.py
@@ -479,12 +479,15 @@ fi
             for t in self.tap_list:
                 isfirst_pack = True
                 direct_first = False
-                tap_packs = self.helper.get_tap_packs(t)
 
                 if t == "direct":
-                    if not tap_packs["formulae"] and not tap_packs["casks"]:
-                        continue
                     direct_first = True
+                    tap_packs: dict[str, list[str]] = {
+                        "formulae": [],
+                        "casks": [],
+                    }
+                else:
+                    tap_packs = self.helper.get_tap_packs(t)
 
                 if not self.helper.opt["caskonly"]:
                     output += first_tap_pack_write(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ def check_brew(tmp_path_factory):
         if not (Path(bf.opt["cache"]) / "api/formula.jws.json").exists():
             # pseudo code to download api json
             bf.helper.proc("brew search python")
+    bf.helper.proc("command brew install wget")
     os.environ["HOMEBREW_API_AUTO_UPDATE_SECS"] = "100000"
     os.environ["HOMEBREW_AUTO_UPDATE_SECS"] = "100000"
     if "HOMEBREW_BREWFILE_VERBOSE" in os.environ:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,17 +23,21 @@ def check_brew(tmp_path_factory):
 
 @pytest.fixture(scope="session", autouse=False)
 def tap(tmp_path_factory):
+    taps = ["rcmdnk/rcmdnkpac", "rcmdnk/rcmdnkcask"]
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
     with FileLock(root_tmp_dir / "tap.lock"):
         bf = brew_file.BrewFile({})
-        bf.helper.proc("brew tap rcmdnk/rcmdnkpac")
-        bf.helper.proc("brew tap rcmdnk/rcmdnkcask")
+        bf.helper.proc(f"brew tap {taps[0]}")
+        bf.helper.proc(f"brew tap {taps[1]}")
+    return taps
 
 
 @pytest.fixture(scope="session", autouse=False)
 def python(tmp_path_factory):
+    python_formula = "python@3.10"
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
     with FileLock(root_tmp_dir / "python.lock"):
         bf = brew_file.BrewFile({})
         # To ignore 2to3 conflict with OS's python (@macOS on GitHub Actions)
-        bf.helper.proc("brew install python@3.10", exit_on_err=False)
+        bf.helper.proc(f"brew install {python_formula}", exit_on_err=False)
+    return python_formula

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ def check_brew(tmp_path_factory):
         if not (Path(bf.opt["cache"]) / "api/formula.jws.json").exists():
             # pseudo code to download api json
             bf.helper.proc("brew search python")
-    bf.helper.proc("brew install wget")
     os.environ["HOMEBREW_API_AUTO_UPDATE_SECS"] = "100000"
     os.environ["HOMEBREW_AUTO_UPDATE_SECS"] = "100000"
     if "HOMEBREW_BREWFILE_VERBOSE" in os.environ:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def tap(tmp_path_factory):
 
 @pytest.fixture(scope="session", autouse=False)
 def python(tmp_path_factory):
-    python_formula = "python@3.10"
+    python_formula = "python@3.13"
     root_tmp_dir = tmp_path_factory.getbasetemp().parent
     with FileLock(root_tmp_dir / "python.lock"):
         bf = brew_file.BrewFile({})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def check_brew(tmp_path_factory):
         if not (Path(bf.opt["cache"]) / "api/formula.jws.json").exists():
             # pseudo code to download api json
             bf.helper.proc("brew search python")
-    bf.helper.proc("command brew install wget")
+    bf.helper.proc("brew install wget")
     os.environ["HOMEBREW_API_AUTO_UPDATE_SECS"] = "100000"
     os.environ["HOMEBREW_AUTO_UPDATE_SECS"] = "100000"
     if "HOMEBREW_BREWFILE_VERBOSE" in os.environ:

--- a/tests/files/BrewfileTestLinux
+++ b/tests/files/BrewfileTestLinux
@@ -1,0 +1,23 @@
+# Before commands
+before echo before
+
+# tap repositories and their packages
+
+tap homebrew/core
+brew python@3.10
+brew vim --HEAD
+
+# Main file
+main BrewfileMain
+
+# Additional files
+file BrewfileExt
+file BrewfileExt2
+file BrewfileNotExist
+file ~/BrewfileHomeForTestingNotExists
+
+# Other commands
+echo other commands
+
+# After commands
+after echo after

--- a/tests/test_brew_file.py
+++ b/tests/test_brew_file.py
@@ -223,7 +223,6 @@ def test_read_all(bf, tap):
         "vim": " --HEAD",
     }
     assert bf.get_list("tap_input") == {
-        "direct",
         "homebrew/cask",
         "homebrew/core",
         "rcmdnk/rcmdnkcask",

--- a/tests/test_brew_helper.py
+++ b/tests/test_brew_helper.py
@@ -220,7 +220,7 @@ def test_get_formula_info(helper):
     assert "installed" in info
 
 
-def test_get_formula_aliases(helper):
+def test_get_formula_aliases(helper, python):
     aliases = helper.get_formula_aliases()
     assert aliases["homebrew/core"]["python"].startswith("python@")
 

--- a/tests/test_brew_helper.py
+++ b/tests/test_brew_helper.py
@@ -186,7 +186,7 @@ def test_brew_val(helper):
 
 def test_get_formula_list(helper, python):
     formula_list = helper.get_formula_list()
-    assert "python@3.10" in formula_list
+    assert python in formula_list
 
 
 def test_get_cask_list(helper):
@@ -196,51 +196,53 @@ def test_get_cask_list(helper):
 
 
 def test_get_info(helper, python):
-    info = helper.get_info("python@3.10")
-    assert info["python@3.10"]["installed"][0]["used_options"] == []
+    info = helper.get_info()["formulae"][python]
+    assert info["installed"][0]["used_options"] == []
 
 
 def test_get_installed(helper, python):
-    installed = helper.get_installed("python@3.10")
+    installed = helper.get_installed(python)
     # brew version can contained additional number with '_'
-    assert installed["version"].split("_")[0].startswith("3.10")
+    assert installed["version"].split("_")[0].startswith(python.split("@")[1])
 
 
 def test_get_option(helper, python):
-    opt = helper.get_option("python@3.10")
+    opt = helper.get_option(python)
     assert opt == ""
 
 
 def test_get_formula_info(helper):
-    info = helper.get_formula_info()
-    assert "name" in info[0]
-    assert "tap" in info[0]
-    assert "aliases" in info[0]
-    assert "linked_keg" in info[0]
-    assert "installed" in info[0]
+    info = list(helper.get_info()["formulae"].values())[0]
+    assert "name" in info
+    assert "tap" in info
+    assert "aliases" in info
+    assert "linked_keg" in info
+    assert "installed" in info
 
 
 def test_get_formula_aliases(helper):
     aliases = helper.get_formula_aliases()
-    assert aliases["python"].startswith("python@")
+    assert aliases["homebrew/core"]["python"].startswith("python@")
 
 
 def test_get_tap_packs(helper, tap):
-    packs = helper.get_tap_packs("rcmdnk/rcmdnkpac")
-    assert "sentaku" in packs
+    packs = helper.get_tap_packs(tap[0])
+    assert "sentaku" in packs["formulae"]
 
 
 def test_get_cask_info(helper):
     if not brew_file.is_mac():
         pytest.skip("only for mac")
-    info = helper.get_cask_info()
-    assert info[0]["tap"] == "homebrew/cask"
+    info = list(helper.get_info()["casks"].values())[0]
+    assert "token" in info
+    assert "tap" in info
+    assert "old_tokens" in info
 
 
 def test_get_tap_casks(helper, tap):
     if not brew_file.is_mac():
         pytest.skip("only for mac")
-    casks = helper.get_tap_casks("rcmdnk/rcmdnkcask")
+    casks = helper.get_tap_packs(tap[1])["casks"]
     assert "vem" in casks
 
 

--- a/tests/test_brew_info.py
+++ b/tests/test_brew_info.py
@@ -255,7 +255,6 @@ def test_read(brew_info):
     assert brew_info.brew_input_opt == {"python@3.10": "", "vim": " --HEAD"}
     assert brew_info.brew_input == ["python@3.10", "vim"]
     assert brew_info.tap_input == [
-        "direct",
         "homebrew/core",
         "homebrew/cask",
         "rcmdnk/rcmdnkcask",

--- a/tests/test_brew_info.py
+++ b/tests/test_brew_info.py
@@ -8,9 +8,7 @@ from . import brew_file
 @pytest.fixture
 def brew_info():
     file = "BrewfileTest" if brew_file.is_mac() else "BrewfileTestLinux"
-    bf = brew_file.BrewFile(
-        {"input": Path(__file__).parent / "files" / file}
-    )
+    bf = brew_file.BrewFile({"input": Path(__file__).parent / "files" / file})
     return bf.brewinfo
 
 
@@ -331,11 +329,13 @@ def test_write(brew_info, tmp_path, tap):
     brew_info.helper.opt["form"] = "bundle"
     brew_info.write()
     if brew_file.is_mac():
-        cask_tap = "tap 'homebrew/cask'\n\ntap 'rcmdnk/rcmdnkcask'\n"
+        cask_tap1 = "\ntap 'homebrew/cask'\n\ntap 'rcmdnk/rcmdnkcask'\n"
+        cask_tap2 = "\nbrew tap homebrew/cask\n\nbrew tap rcmdnk/rcmdnkcask\n"
         appstore1 = "\n# App Store applications\nmas '', id: Keynote\n"
         appstore2 = "\n# App Store applications\nmas install Keynote\n"
     else:
-        cask_tap = ""
+        cask_tap1 = ""
+        cask_tap2 = ""
         appstore1 = ""
         appstore2 = ""
 
@@ -348,7 +348,7 @@ def test_write(brew_info, tmp_path, tap):
 # tap repositories and their packages
 
 tap 'homebrew/core'
-{cask_tap}{appstore1}
+{cask_tap1}{appstore1}
 # Main file
 #main 'BrewfileMain'
 
@@ -390,7 +390,7 @@ echo before
 # tap repositories and their packages
 
 brew tap homebrew/core
-{cask_tap}{appstore2}
+{cask_tap2}{appstore2}
 # Main file
 #main BrewfileMain
 


### PR DESCRIPTION
Resolve #283
Resolve #282
Related #285

* Use `brew info --json=v2 --installed` to get information of installed formuale/casks.
(Replaced for `brew info --json=v1 --eval-all`, `brew info --json=v2 --eval-all`, `brew list ...`)
* Use `brew tap-info --json --installed` to get all formulae/casks in the tap.

Estimated time to run `brew init` for ~200 formulae, ~30 casks :

* Old (v9.1.4): ~30s
* New (this PR): ~6s