### PR TITLE
fix: Fix command execution for fish 4.0.0 compatibility

### DIFF
--- a/etc/brew-wrap.fish
+++ b/etc/brew-wrap.fish
@@ -4,7 +4,7 @@ function brew
   set -l exe command brew
 
   if not type -q brew-file
-    $exe $argv
+    eval "$exe $argv"
     return
   end
 
@@ -81,7 +81,7 @@ function mas
   end
 
   # Execute command
-  $exe $argv
+  eval "$exe $argv"
 end
 
 # whalebrew command wrapper for brew-file
@@ -100,7 +100,7 @@ function whalebrew
   end
 
   # Execute command
-  $exe $argv
+  eval "$exe $argv"
 end
 
 # code (for VSCode) command wrapper for brew-file
@@ -119,7 +119,7 @@ function code
   end
 
   # Execute command
-  $exe $argv
+  eval "$exe $argv"
 end
 
 # cursor (for Cursor) command wrapper for brew-file
@@ -138,5 +138,5 @@ function cursor
   end
 
   # Execute command
-  $exe $argv
+  eval "$exe $argv"
 end


### PR DESCRIPTION
Fish 4.0.0 introduced a breaking change ([PR #10249](https://github.com/fish-shell/fish-shell/pull/10249)) that prevents executing keywords stored in variables.

Changed to `eval "$exe $argv"` in all wrapper functions.