### PR TITLE
fix: Homebrew 4.0+ compatibility and sane defaults

### DIFF
--- a/bin/brew-file
+++ b/bin/brew-file
@@ -1358,7 +1358,7 @@ class BrewFile:
         if not opt['input'].name:
             opt['input'] = self.get_input_path()
         opt['backup'] = os.getenv('HOMEBREW_BREWFILE_BACKUP', '')
-        opt['form'] = None
+        opt['form'] = os.getenv('HOMEBREW_BREWFILE_FORM', None) or None
         opt['leaves'] = to_bool(os.getenv('HOMEBREW_BREWFILE_LEAVES', ''))
         opt['on_request'] = to_bool(
             os.getenv('HOMEBREW_BREWFILE_ON_REQUEST', ''),
@@ -3898,7 +3898,10 @@ def main() -> int:
         '[homebrew-bundle]'
         '(https://github.com/Homebrew/homebrew-bundle).\n'
         'command or cmd    : brew install vim --HEAD --with-lua\n'
-        '  Can be used as a shell script.\n',
+        '  Can be used as a shell script.\n'
+        'You can set this by environmental variable, '
+        'HOMEBREW_BREWFILE_FORM, like:\n'
+        '    export HOMEBREW_BREWFILE_FORM=file',
     )
 
     leaves_parser = argparse.ArgumentParser(**arg_parser_opts)

--- a/src/brew_file/brew_file.py
+++ b/src/brew_file/brew_file.py
@@ -101,7 +101,7 @@ class BrewFile:
         if not opt['input'].name:
             opt['input'] = self.get_input_path()
         opt['backup'] = os.getenv('HOMEBREW_BREWFILE_BACKUP', '')
-        opt['form'] = None
+        opt['form'] = os.getenv('HOMEBREW_BREWFILE_FORM', None) or None
         opt['leaves'] = to_bool(os.getenv('HOMEBREW_BREWFILE_LEAVES', ''))
         opt['on_request'] = to_bool(
             os.getenv('HOMEBREW_BREWFILE_ON_REQUEST', ''),

--- a/src/brew_file/main.py
+++ b/src/brew_file/main.py
@@ -138,7 +138,10 @@ def main() -> int:
         '[homebrew-bundle]'
         '(https://github.com/Homebrew/homebrew-bundle).\n'
         'command or cmd    : brew install vim --HEAD --with-lua\n'
-        '  Can be used as a shell script.\n',
+        '  Can be used as a shell script.\n'
+        'You can set this by environmental variable, '
+        'HOMEBREW_BREWFILE_FORM, like:\n'
+        '    export HOMEBREW_BREWFILE_FORM=file',
     )
 
     leaves_parser = argparse.ArgumentParser(**arg_parser_opts)

--- a/tests/test_brew_file.py
+++ b/tests/test_brew_file.py
@@ -210,6 +210,25 @@ def test_read(bf: BrewFile, tmp_path: Path) -> None:
     assert ret.file == Path(f3)
 
 
+def test_read_all_form_persist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    main = tmp_path / 'Brewfile'
+    main.write_text('brew fish\nfile hostfile\n')
+    (tmp_path / 'hostfile').write_text("brew 'jq'\n")
+
+    monkeypatch.delenv('HOMEBREW_BREWFILE_FORM', raising=False)
+    bf = BrewFile({'input': str(main)})
+    bf.read_all(force=True)
+    assert bf.opt['form'] == 'bundle'
+
+    monkeypatch.setenv('HOMEBREW_BREWFILE_FORM', 'file')
+    bf2 = BrewFile({'input': str(main)})
+    bf2.read_all(force=True)
+    assert bf2.opt['form'] == 'file'
+
+
 def test_repo_name(bf: BrewFile) -> None:
     bf.opt['repo'] = 'git@github.com:abc/def.git'
     assert bf.repo_name() == 'def'


### PR DESCRIPTION
## Summary

Homebrew 4.0 (April 2023) switched to API mode, which changed some assumptions brew-file relied on:

1. `homebrew/core` and `homebrew/cask` no longer exist as git repos, but `brew file init` still adds them to the tap list. `get_tap_packs()` then hits a KeyError looking them up in `brew tap-info --json --installed`.

2. The Brewfile includes every installed formula by default, including transitive deps. On most systems that's hundreds of entries that brew would pull in automatically.

3. Taps with no installed packages still get a header in the output.

4. The output format can't be set persistently. Using `main` (which requires `file` format) means passing `-F file` every time.

## Changes

- Stop adding `homebrew/core` and `homebrew/cask` in API mode, packages install via the API without taps
- Return empty lists from `get_tap_packs()` for taps not in `brew tap-info` output
- Default `HOMEBREW_BREWFILE_LEAVES` to `1` (only leaf packages). Opt out with `HOMEBREW_BREWFILE_LEAVES=0`
- Skip tap sections when no installed packages belong to that tap
- Add `HOMEBREW_BREWFILE_FORM` env var to persist format choice

## Breaking change

`HOMEBREW_BREWFILE_LEAVES` now defaults to `1` (previously `0`). Existing users who never set this variable will see shorter Brewfiles on the next run — only leaf packages (explicitly installed, not deps) are included. To restore the previous behavior: `export HOMEBREW_BREWFILE_LEAVES=0`.