### PR TITLE
fix: handle Homebrew 6 empty installed info and tap-info failures

### DIFF
--- a/bin/brew-file
+++ b/bin/brew-file
@@ -467,7 +467,11 @@ class BrewHelper:
         installed = {}
         package_info = self.get_info()['formulae'][package]
 
-        if (version := package_info['linked_keg']) is None:
+        if (version := package_info.get('linked_keg')) is None:
+            # Homebrew 6 can list a formula with an empty installed list.
+            # https://github.com/rcmdnk/homebrew-file/issues/391
+            if not package_info.get('installed'):
+                return installed
             version = package_info['installed'][-1]['version']
 
         if version != '':
@@ -499,15 +503,35 @@ class BrewHelper:
         alias: bool = False,
     ) -> dict[str, list[str]]:
         if self.taps is None:
-            _, lines = self.proc(
+            ret, lines = self.proc(
                 cmd='brew tap-info --json --installed',
                 print_cmd=False,
                 print_out=False,
                 exit_on_err=False,
                 separate_err=True,
             )
-            lines = lines[lines.index('[') :]
-            data = json.loads(''.join(lines))
+            # brew tap-info can return non-zero even with valid JSON output
+            # when homebrew/core or homebrew/cask is not installed.
+            # https://github.com/rcmdnk/homebrew-file/issues/373
+            json_start = next(
+                (i for i, line in enumerate(lines) if line.startswith('[')),
+                None,
+            )
+            data = None
+            if json_start is not None:
+                try:
+                    data = json.loads(''.join(lines[json_start:]))
+                except json.JSONDecodeError:
+                    data = None
+            if data is None:
+                # brew itself may fail and return no JSON output.
+                # https://github.com/rcmdnk/homebrew-file/issues/391
+                msg = (
+                    'Failed to get tap information: `brew tap-info --json '
+                    f'--installed` exited with status {ret} and did not '
+                    'return JSON output.\n' + '\n'.join(lines)
+                )
+                raise RuntimeError(msg)
             self.taps = {x['name']: x for x in data}
 
         packs = {

--- a/bin/brew-file
+++ b/bin/brew-file
@@ -468,8 +468,6 @@ class BrewHelper:
         package_info = self.get_info()['formulae'][package]
 
         if (version := package_info.get('linked_keg')) is None:
-            # Homebrew 6 can list a formula with an empty installed list.
-            # https://github.com/rcmdnk/homebrew-file/issues/391
             if not package_info.get('installed'):
                 return installed
             version = package_info['installed'][-1]['version']
@@ -510,9 +508,6 @@ class BrewHelper:
                 exit_on_err=False,
                 separate_err=True,
             )
-            # brew tap-info can return non-zero even with valid JSON output
-            # when homebrew/core or homebrew/cask is not installed.
-            # https://github.com/rcmdnk/homebrew-file/issues/373
             json_start = next(
                 (i for i, line in enumerate(lines) if line.startswith('[')),
                 None,
@@ -524,8 +519,6 @@ class BrewHelper:
                 except json.JSONDecodeError:
                     data = None
             if data is None:
-                # brew itself may fail and return no JSON output.
-                # https://github.com/rcmdnk/homebrew-file/issues/391
                 msg = (
                     'Failed to get tap information: `brew tap-info --json '
                     f'--installed` exited with status {ret} and did not '

--- a/src/brew_file/brew_helper.py
+++ b/src/brew_file/brew_helper.py
@@ -315,8 +315,6 @@ class BrewHelper:
         package_info = self.get_info()['formulae'][package]
 
         if (version := package_info.get('linked_keg')) is None:
-            # Homebrew 6 can list a formula with an empty installed list.
-            # https://github.com/rcmdnk/homebrew-file/issues/391
             if not package_info.get('installed'):
                 return installed
             version = package_info['installed'][-1]['version']
@@ -357,9 +355,6 @@ class BrewHelper:
                 exit_on_err=False,
                 separate_err=True,
             )
-            # brew tap-info can return non-zero even with valid JSON output
-            # when homebrew/core or homebrew/cask is not installed.
-            # https://github.com/rcmdnk/homebrew-file/issues/373
             json_start = next(
                 (i for i, line in enumerate(lines) if line.startswith('[')),
                 None,
@@ -371,8 +366,6 @@ class BrewHelper:
                 except json.JSONDecodeError:
                     data = None
             if data is None:
-                # brew itself may fail and return no JSON output.
-                # https://github.com/rcmdnk/homebrew-file/issues/391
                 msg = (
                     'Failed to get tap information: `brew tap-info --json '
                     f'--installed` exited with status {ret} and did not '

--- a/src/brew_file/brew_helper.py
+++ b/src/brew_file/brew_helper.py
@@ -314,7 +314,11 @@ class BrewHelper:
         installed = {}
         package_info = self.get_info()['formulae'][package]
 
-        if (version := package_info['linked_keg']) is None:
+        if (version := package_info.get('linked_keg')) is None:
+            # Homebrew 6 can list a formula with an empty installed list.
+            # https://github.com/rcmdnk/homebrew-file/issues/391
+            if not package_info.get('installed'):
+                return installed
             version = package_info['installed'][-1]['version']
 
         if version != '':
@@ -346,15 +350,35 @@ class BrewHelper:
         alias: bool = False,
     ) -> dict[str, list[str]]:
         if self.taps is None:
-            _, lines = self.proc(
+            ret, lines = self.proc(
                 cmd='brew tap-info --json --installed',
                 print_cmd=False,
                 print_out=False,
                 exit_on_err=False,
                 separate_err=True,
             )
-            lines = lines[lines.index('[') :]
-            data = json.loads(''.join(lines))
+            # brew tap-info can return non-zero even with valid JSON output
+            # when homebrew/core or homebrew/cask is not installed.
+            # https://github.com/rcmdnk/homebrew-file/issues/373
+            json_start = next(
+                (i for i, line in enumerate(lines) if line.startswith('[')),
+                None,
+            )
+            data = None
+            if json_start is not None:
+                try:
+                    data = json.loads(''.join(lines[json_start:]))
+                except json.JSONDecodeError:
+                    data = None
+            if data is None:
+                # brew itself may fail and return no JSON output.
+                # https://github.com/rcmdnk/homebrew-file/issues/391
+                msg = (
+                    'Failed to get tap information: `brew tap-info --json '
+                    f'--installed` exited with status {ret} and did not '
+                    'return JSON output.\n' + '\n'.join(lines)
+                )
+                raise RuntimeError(msg)
             self.taps = {x['name']: x for x in data}
 
         packs = {

--- a/tests/test_brew_helper.py
+++ b/tests/test_brew_helper.py
@@ -330,3 +330,117 @@ def test_get_desc_no_desc_key(helper: BrewHelper) -> None:
         'casks': {},
     }
     assert helper.get_desc('git', 'formulae') == ''
+
+
+def test_get_installed_linked_keg(helper: BrewHelper) -> None:
+    helper.info = {
+        'formulae': {
+            'pkg': {
+                'linked_keg': '1.2.3',
+                'installed': [
+                    {'version': '1.2.2'},
+                    {'version': '1.2.3'},
+                ],
+            },
+        },
+        'casks': {},
+    }
+    assert helper.get_installed('pkg') == {'version': '1.2.3'}
+
+
+def test_get_installed_no_linked_keg(helper: BrewHelper) -> None:
+    helper.info = {
+        'formulae': {
+            'pkg': {
+                'linked_keg': None,
+                'installed': [
+                    {'version': '1.2.2'},
+                    {'version': '1.2.3'},
+                ],
+            },
+        },
+        'casks': {},
+    }
+    assert helper.get_installed('pkg') == {'version': '1.2.3'}
+
+
+def test_get_installed_reinstall_keg(helper: BrewHelper) -> None:
+    helper.info = {
+        'formulae': {
+            'pkg': {
+                'linked_keg': '1.2.3',
+                'installed': [{'version': '1.2.3.reinstall'}],
+            },
+        },
+        'casks': {},
+    }
+    assert helper.get_installed('pkg') == {'version': '1.2.3.reinstall'}
+
+
+def test_get_installed_empty_installed(helper: BrewHelper) -> None:
+    # Homebrew 6 can list a formula with an empty installed list.
+    # https://github.com/rcmdnk/homebrew-file/issues/391
+    helper.info = {
+        'formulae': {'pkg': {'linked_keg': None, 'installed': []}},
+        'casks': {},
+    }
+    assert helper.get_installed('pkg') == {}
+    assert helper.get_option('pkg') == ''
+
+
+def test_get_tap_packs(
+    helper: BrewHelper, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tap_info = [
+        'Warning: some warning',
+        '[',
+        '{"name": "rcmdnk/file",',
+        '"formula_names": ["rcmdnk/file/brew-file"],',
+        '"cask_tokens": ["rcmdnk/file/dummy-cask"]}',
+        ']',
+    ]
+    # brew tap-info can return non-zero even with valid JSON output
+    monkeypatch.setattr(helper, 'proc', lambda **_kwargs: (1, tap_info))
+    helper.opt['full_name'] = False
+    packs = helper.get_tap_packs('rcmdnk/file')
+    assert packs == {'formulae': ['brew-file'], 'casks': ['dummy-cask']}
+
+
+def test_get_tap_packs_compact_json(
+    helper: BrewHelper, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tap_info = [
+        '[{"name": "rcmdnk/file", "formula_names": [], "cask_tokens": []}]',
+    ]
+    monkeypatch.setattr(helper, 'proc', lambda **_kwargs: (0, tap_info))
+    helper.opt['full_name'] = False
+    packs = helper.get_tap_packs('rcmdnk/file')
+    assert packs == {'formulae': [], 'casks': []}
+
+
+def test_get_tap_packs_no_json(
+    helper: BrewHelper, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # https://github.com/rcmdnk/homebrew-file/issues/391
+    monkeypatch.setattr(
+        helper,
+        'proc',
+        lambda **_kwargs: (1, ['Error: Too many open files']),
+    )
+    with pytest.raises(RuntimeError) as e:
+        helper.get_tap_packs('rcmdnk/file')
+    assert 'brew tap-info' in str(e.value)
+    assert 'Error: Too many open files' in str(e.value)
+
+
+def test_get_tap_packs_broken_json(
+    helper: BrewHelper, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        helper,
+        'proc',
+        lambda **_kwargs: (1, ['[', '{"name": "rcmdnk/file"']),
+    )
+    with pytest.raises(RuntimeError) as e:
+        helper.get_tap_packs('rcmdnk/file')
+    assert 'brew tap-info' in str(e.value)


### PR DESCRIPTION
## Summary

Under Homebrew 6, brew-file can crash after almost any `brew` command run via brew-wrap (#391). Two separate crashes were reported:

1. `IndexError: list index out of range` in `get_installed()`: Homebrew 6's `brew info --json=v2 --installed` can list a formula whose `installed` array is empty while `linked_keg` is `null`. The candidate list is built from Cellar racks (`Formulary.from_rack`), while each entry's `installed` array is resolved from the formula's `possible_names`, so the two can disagree.

2. `ValueError: list.index(x): x not in list` in `get_tap_packs()`: when `brew tap-info --json --installed` itself fails and prints no JSON (e.g. `Error: Too many open files`, seen since tap-info was parallelized in Homebrew 6.0.9), the `lines.index('[')` lookup added for #373 raises an unhandled `ValueError`.

## Changes

- `get_installed()` returns an empty dict when a formula has no `linked_keg` and an empty `installed` list, instead of crashing. A missing `linked_keg` key is also tolerated.
- `get_tap_packs()` finds the JSON start with `startswith('[')` (so compact single-line JSON is also accepted) and raises a clear `RuntimeError` including the command output when no valid JSON is returned, instead of an unhandled traceback. Non-zero exit status with valid JSON output is still accepted, keeping the #373 behavior.

## User-facing impact

- `brew` commands wrapped by brew-wrap no longer die with a Python traceback on Homebrew 6 when `brew info --json=v2 --installed` returns formulae without installed kegs.
- If `brew tap-info` fails completely, users get an explanatory error message including brew's output instead of `ValueError: '[' is not in list`.

## Tests

- Added 8 unit tests covering `get_installed` (linked keg, unlinked, `.reinstall` keg, empty installed list) and `get_tap_packs` (warning lines before JSON, compact JSON, no JSON, broken JSON).
- Full non-destructive suite passes (151 tests).

Fixes #391