### PR TITLE
fix: skip cask evaluation on Linux in get_all_info

### DIFF
--- a/bin/brew-file
+++ b/bin/brew-file
@@ -391,7 +391,10 @@ class BrewHelper:
 
         self.all_info = {
             'formulae': self.get_each_type_info('formulae'),
-            'casks': self.get_each_type_info('casks'),
+            # Casks are not supported on Linux. Evaluating them can even
+            # fail there: Homebrew 6 raises "key not found: :prefpanedir"
+            # for casks with macOS-only artifacts.
+            'casks': self.get_each_type_info('casks') if is_mac() else {},
         }
         return self.all_info
 

--- a/src/brew_file/brew_helper.py
+++ b/src/brew_file/brew_helper.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
+from .utils import is_mac
+
 
 class ProcParams(TypedDict):
     """Parameters for BrewHelper.proc()."""
@@ -238,7 +240,10 @@ class BrewHelper:
 
         self.all_info = {
             'formulae': self.get_each_type_info('formulae'),
-            'casks': self.get_each_type_info('casks'),
+            # Casks are not supported on Linux. Evaluating them can even
+            # fail there: Homebrew 6 raises "key not found: :prefpanedir"
+            # for casks with macOS-only artifacts.
+            'casks': self.get_each_type_info('casks') if is_mac() else {},
         }
         return self.all_info
 

--- a/tests/test_brew_helper.py
+++ b/tests/test_brew_helper.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from . import brew_file as brew_file_module
 from .brew_file import BrewFile, BrewHelper, CmdError, is_mac
 
 
@@ -290,6 +291,29 @@ def test_get_all_info(helper: BrewHelper) -> None:
 
     # Test caching
     assert helper.get_all_info() is info
+
+
+def test_get_all_info_non_mac(
+    helper: BrewHelper, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Casks must not be evaluated on Linux, where get_each_type_info('casks')
+    # can fail with Homebrew 6
+    monkeypatch.setattr(brew_file_module, 'is_mac', lambda: False)
+    monkeypatch.setattr(
+        helper,
+        'get_json_info',
+        lambda *_args, **_kwargs: ['Error: failed'],
+    )
+    monkeypatch.setattr(
+        helper,
+        'get_each_type_info',
+        lambda package_type: {package_type: {'name': package_type}},
+    )
+    info = helper.get_all_info()
+    assert info == {
+        'formulae': {'formulae': {'name': 'formulae'}},
+        'casks': {},
+    }
 
 
 def test_get_desc_formula(helper: BrewHelper) -> None:


### PR DESCRIPTION
## Summary

The `test (ubuntu-latest, 3.x)` CI jobs have been failing on `main` since June (first seen in the run for eb03e39). The failing test is `test_get_all_info`:

```
RuntimeError: Failed to get info of all casks.
::error::key not found: :prefpanedir
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cask/config.rb:213:in 'Hash#fetch'
```

On Linux, Homebrew 6 fails to generate cask JSON for casks with macOS-only artifact directories (`Cask#to_h` fetches `:prefpanedir` etc. from the cask config, which does not contain them on Linux). `brew info --json=v2 --eval-all` fails for the same reason, so `get_all_info()` always falls back to `get_each_type_info('casks')` and hits this unhandled error pattern.

## Changes

- `get_all_info()` no longer evaluates casks on non-mac platforms and returns an empty `casks` dict instead, matching the `is_mac()` guards used elsewhere (casks are not supported on Linux anyway).
- Added a unit test for the non-mac path (`test_get_all_info_non_mac`, fully mocked).

## User-facing impact

`brew file` commands that need all-package info (e.g. `brew file get_files` flows using `get_all_info`) no longer abort with `RuntimeError: Failed to get info of all casks.` on Linux with Homebrew 6.

Note: this is independent of #392 (issue #391); the ubuntu test failures on that PR's CI come from this pre-existing problem.