### PR TITLE
fix: exclude linux_sandbox from brew doctor checks in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,8 +38,12 @@ echo Install Brew-file...
 brew install rcmdnk/file/brew-file
 
 if [ $brew_installed -eq 0 ];then
-  # Do not check stray files
-  read -ra checks < <(brew doctor --list-checks | grep -vE '(dylibs|static_libs|headers|cask|brew_git_branch)'|tr '\n' ' ')
+  # Do not check stray files.
+  # linux_sandbox is excluded, too: Homebrew 6 requires rootless Bubblewrap
+  # and unprivileged user namespaces for the Linux sandbox, which are not
+  # always available (e.g. GitHub Actions runners), while brew still works
+  # without the sandbox.
+  read -ra checks < <(brew doctor --list-checks | grep -vE '(dylibs|static_libs|headers|cask|brew_git_branch|linux_sandbox)'|tr '\n' ' ')
   if ! brew doctor "${checks[@]}";then
     echo Check brew environment!
     exit 1


### PR DESCRIPTION
## Summary

The `install (ubuntu-latest)` CI job fails because `install.sh` runs `brew doctor` after installing Homebrew, and Homebrew 6 added a new `check_linux_sandbox` doctor check. It fails on systems where unprivileged user namespaces are unavailable, including GitHub Actions ubuntu runners (restricted via AppArmor since ubuntu-24.04):

```
Warning: Bubblewrap is installed but cannot create a rootless sandbox.
...
Check brew environment!
Error: Process completed with exit code 1.
```

Homebrew still works without the sandbox (builds run unsandboxed with a warning), so a failing sandbox check should not make the whole installation fail.

## Changes

- Add `linux_sandbox` to the existing `grep -vE` exclusion list for `brew doctor --list-checks`, alongside `dylibs|static_libs|headers|cask|brew_git_branch`. On macOS the pattern matches nothing and behavior is unchanged.

Verified with shellcheck.